### PR TITLE
Warning on build

### DIFF
--- a/source/field.hpp
+++ b/source/field.hpp
@@ -612,5 +612,7 @@ void Field::startSweep(int x, int y, POSOFCELL pos, DIR_X x_dir, DIR_Y y_dir)
         cells[x][y].reveal();
         --hiddenCells;
         break;
+    default:
+        break;
     }
 }


### PR DESCRIPTION
PROBLEM:
When I cloned this repository I got warning when executing make.

```cpp
In file included from source/mine.cpp:1:
source/field.hpp:575:13: warning: enumeration value 'MINE' not handled in switch [-Wswitch]
    switch (cells[x][y].state)
            ^~~~~~~~~~~~~~~~~
source/field.hpp:575:13: note: add missing switch cases
    switch (cells[x][y].state)
            ^
1 warning generated.

```
SOLUTION:
I added
```cpp
    default:
        break;
```
in [line 615](https://github.com/margual56/minesweeper-cli/blob/5a1800618c69ae20d88e7a554a3cda3750cbe4cd/source/field.hpp#L615)